### PR TITLE
mirroring broken, post-update requires GL_RC

### DIFF
--- a/src/gl-mirror-shell
+++ b/src/gl-mirror-shell
@@ -16,8 +16,10 @@ if echo $SSH_ORIGINAL_COMMAND | egrep git-upload\|git-receive >/dev/null
 then
 
     # the (special) admin post-update hook needs these, so we cheat
+    export GL_RC
     export GL_ADMINDIR
     export GL_BINDIR
+    GL_RC=$(get_rc_val GL_RC)
     GL_ADMINDIR=$(get_rc_val GL_ADMINDIR)
     GL_BINDIR=$(  get_rc_val GL_BINDIR)
 


### PR DESCRIPTION
The mirroring functionality doesn't work without exporting GL_RC.

Error message when pushing to the master:
Writing objects: 100% (10/10), 835 bytes, done.
Total 10 (delta 4), reused 0 (delta 0)
hooks/post-update: line 3: die: command not found
ENV GL_RC not set
BEGIN failed--compilation aborted at /git/gitolite/bin/gl-compile-conf line 16.
To git@slave.internal:gitolite-admin.git
   2e34f2b..55849d0  master -> master
