### PR TITLE
Support Windows Line Endings in Gitolite.

### DIFF
--- a/src/gitolite.pm
+++ b/src/gitolite.pm
@@ -101,6 +101,8 @@ sub wrap_open {
 
 sub wrap_print {
     my ($file, @text) = @_;
+    my $line;
+    for $line(@text) { $line =~ s/\r//g; } # clean up DOS line endings.
     my $fh = wrap_open(">", $file);
     print $fh @text;
     close($fh) or die "$ABRT close $file failed: $! at ", (caller)[1], " line ", (caller)[2], "\n";


### PR DESCRIPTION
Using Msysgit bash shell on Windows, passing in a file into
setperms confuses Gitolite since it doesn't parse out the
permissions correctly since it contains Windows CR Line Feed.
It saves it correctly, but cannot verify it in the regex.

By cleaning out any CR character when that gets inputed, solves
the problem. Mysgit clients can continue using the default
settings. They could easily fix this issue by setting their
editors to LF instead of CR but that isn't by default.
