### PR TITLE
do not assume /bin/sh is bash. For example on Solaris it is really the sh

### DIFF
--- a/contrib/adc/able
+++ b/contrib/adc/able
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . $(dirname $0)/adc.common-functions
 

--- a/contrib/adc/fork
+++ b/contrib/adc/fork
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . $(dirname $0)/adc.common-functions
 

--- a/contrib/adc/help
+++ b/contrib/adc/help
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . $(dirname $0)/adc.common-functions
 

--- a/contrib/adc/list-trash
+++ b/contrib/adc/list-trash
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . $(dirname $0)/adc.common-functions
 

--- a/contrib/adc/lock
+++ b/contrib/adc/lock
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . $(dirname $0)/adc.common-functions
 

--- a/contrib/adc/restore
+++ b/contrib/adc/restore
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . $(dirname $0)/adc.common-functions
 

--- a/contrib/adc/restrict-admin
+++ b/contrib/adc/restrict-admin
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . $(dirname $0)/adc.common-functions
 

--- a/contrib/adc/rm
+++ b/contrib/adc/rm
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . $(dirname $0)/adc.common-functions
 

--- a/contrib/adc/set-head
+++ b/contrib/adc/set-head
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . $(dirname $0)/adc.common-functions
 

--- a/contrib/adc/su-expand
+++ b/contrib/adc/su-expand
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # adc for someone with admin privs to invoke "expand" on other users.
 

--- a/contrib/adc/su-getperms
+++ b/contrib/adc/su-getperms
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # adc for someone with admin privs to invoke "setperms/getperms" on other
 # users.

--- a/contrib/adc/sudo
+++ b/contrib/adc/sudo
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # this command is pretty cool, even if I may say so myself :)
 

--- a/contrib/adc/trash
+++ b/contrib/adc/trash
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . $(dirname $0)/adc.common-functions
 

--- a/contrib/adc/unlock
+++ b/contrib/adc/unlock
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . $(dirname $0)/adc.common-functions
 

--- a/contrib/adc/watch
+++ b/contrib/adc/watch
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . $(dirname $0)/adc.common-functions
 

--- a/contrib/ldap/ldap-query-example.sh
+++ b/contrib/ldap/ldap-query-example.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2010 Nokia Corporation
 #

--- a/hooks/gitolite-admin/post-update
+++ b/hooks/gitolite-admin/post-update
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 die() { echo "$@"; exit 1; } >&2
 

--- a/src/gl-admin-push
+++ b/src/gl-admin-push
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 die() { echo "$@"; exit 1; } >&2
 

--- a/src/gl-setup
+++ b/src/gl-setup
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 GL_PACKAGE_CONF=/tmp/share/gitolite/conf
 # must be the same as the value for the same variable in

--- a/src/gl-system-install
+++ b/src/gl-system-install
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # install the gitolite software *system wide*.  Not too robust, fancy, etc.,
 # but does have a usage message and catches simple problems.

--- a/src/gl-tool
+++ b/src/gl-tool
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # BEGIN USAGE
 


### PR DESCRIPTION
do not assume /bin/sh is bash. For example on Solaris it is really the sh shell.

With my change, the user PATH decides the location of the bash shell. (This way is also used in the official python docs)
