### PR TITLE
Don't allow gitweb access just because description is set

### DIFF
--- a/src/gitolite.pm
+++ b/src/gitolite.pm
@@ -502,7 +502,7 @@ sub setup_gitweb_access
         system("git config --remove-section gitweb 2>/dev/null");
     }
 
-    return ($desc or can_read($repo, 'gitweb'));
+    return can_read($repo, 'gitweb');
         # this return value is used by the caller to write to projects.list
 }
 


### PR DESCRIPTION
I spent a few perplexed minutes tonight trying to figure out why a project for which I had not specified "R gitweb" was being added to projects.list. After wading through the code for a bit, I found that the setup_gitweb_access used the description being set as a sufficient condition to enable gitweb access. I set description and owners on all projects since they will eventually be publicly available so I found this behavior quite annoying. Here is a patchset changing this. I could not find any places for documentation updates, although I'll gladly submit further patches if needed.

Cheers,
- Ben
