### PR TITLE
Use sed instead of bashism (pattern substitution) in gl-mirror-push

### DIFF
--- a/src/gl-mirror-push
+++ b/src/gl-mirror-push
@@ -60,7 +60,7 @@ slaves="$*"
 # print out the job ID, then redirect all 3 FDs
 export job_id=$$        # can change to something else if needed
 echo "($job_id&) $hn ==== ($repo) ===>" $slaves >&2
-logfile=${GL_LOG/%.log/-mirror-pushes.log}
+logfile=`echo "${GL_LOG}" | sed 's/\.log$/-mirror-pushes.log/'`
 exec >>$logfile 2>&1 </dev/null
 
 # ----------


### PR DESCRIPTION
gl-mirror-push fails with dash as /bin/sh due to the use of bash pattern
substition (${parameter/pattern/string}). Use sed instead.
