### PR TITLE
Enforce cwd to be relative to the gl admin directory when compiling.

### DIFF
--- a/src/gl-compile-conf
+++ b/src/gl-compile-conf
@@ -260,6 +260,7 @@ sub parse_conf_line
     elsif ($line =~ /^include "(.+)"/)
     {
         my $include_glob = $1;
+        wrap_chdir($GL_ADMINDIR);
         for my $file (glob($include_glob =~ m(^/) ? $include_glob : "conf/$include_glob")) {
             die "$ABRT $fragment attempting to include configuration\n" if $fragment ne 'master';
             die "$ABRT included file not found: '$file'\n" unless -f $file;


### PR DESCRIPTION
When the configuration file has an config inclusion, it is opening
and processing the file relative to gitolite-admin. When we manually
run gl-compile-conf from the bin directory, it fails and says
"included file not found: gitolite-test.conf and exists. This
ensures the current working directory when processing that file
is always relative to the config folder.
