### PR TITLE
Fix http_simulate_ssh_connection url unescaping

### DIFF
--- a/src/gitolite-shell
+++ b/src/gitolite-shell
@@ -212,6 +212,7 @@ sub http_simulate_ssh_connection {
         my ($verb) = ( $ENV{PATH_INFO} =~ m(^/(\S+)) );
         my $args = $ENV{QUERY_STRING};
         $args =~ s/\+/ /g;
+        $args =~ s/\%([0-9a-fA-F]{2})/pack('C', hex($1))/seg;
         $ENV{SSH_ORIGINAL_COMMAND} = $verb;
         $ENV{SSH_ORIGINAL_COMMAND} .= " $args" if $args;
         http_print_headers();    # in preparation for the eventual output!


### PR DESCRIPTION
Only '+' sign was unescaped in `http_simulate_ssh_connection()`.
When user translates `ssh git@host perms <repo> + <role> <user>` to
`curl https://host/git/perms?<repo>+%2b+<role>+<user>` nothing happens.
This commit fixes it modifying url unescaping.
