### PR TITLE
install doesn't fail if not git repo install

### DIFF
--- a/install
+++ b/install
@@ -61,7 +61,7 @@ for my $d ($ln, $to) {
 }
 
 chdir($ENV{GL_BINDIR});
-my $version = `([ -x git ] && git describe --tags --long --dirty=-dt) || 'not-git-repo'`;
+my $version = `([ -x git ] && git describe --tags --long --dirty=-dt) || echo 'not-git-repo'`;
 
 if ($to) {
     _mkdir($to);


### PR DESCRIPTION
I am installing gitolite from a tarball of gitolite, not a git repo. This patch means that `install` does not fail.
