### PR TITLE
fix for keysubdirs-as-groups sugar script to support "old style multi-keys" for users

### DIFF
--- a/src/syntactic-sugar/keysubdirs-as-groups
+++ b/src/syntactic-sugar/keysubdirs-as-groups
@@ -20,7 +20,7 @@ sub groupnames {
     my @out     = ();
     my %members = ();
     for my $pk (`find ../keydir/ -name "*.pub"`) {
-        next unless $pk =~ m(.*/([^/]+)/([^/]+)\.pub$);
+        next unless $pk =~ m(.*/([^/]+)/([^/]+?)(?:@[^./]+)?\.pub$);
         next if $1 eq 'keydir';
         $members{$1} .= " $2";
     }


### PR DESCRIPTION
Was perplexed as to why using "keysubdirs-as-groups" wasn't adding my users to the correct groups until I checked the compiled gitolite.conf output and realized it was not ignoring my "old style multi-keys", and was creating a separate entry for each of my users (john@main, john@laptop, etc).  The fix here works here, and should also work for users that are using mutli-keys with email addresses, or users that aren't using the old style multi-keys at all.
