### PR TITLE
Set Content-Type to text/plain for gitolite commands over http

### DIFF
--- a/src/gitolite-shell
+++ b/src/gitolite-shell
@@ -234,5 +234,6 @@ sub http_print_headers {
     print "Expires: Fri, 01 Jan 1980 00:00:00 GMT\r\n";
     print "Pragma: no-cache\r\n";
     print "Cache-Control: no-cache, max-age=0, must-revalidate\r\n";
+    print "Content-Type: text/plain\r\n";
     print "\r\n";
 }


### PR DESCRIPTION
Explicitly set "Content-Type: text/plain" for gitolite commands when
issued over http, so that it is possible to see the output with normal
browsers.
(At least) Apache httpd might set the Content-Type to something
different and triggers a download instead of showing the text directly.

Signed-off-by: Sven Strickroth email@cs-ware.de
