### PR TITLE
sshkey-lint with an ecdsa key doesn't work, simple fix

### DIFF
--- a/src/commands/sshkeys-lint
+++ b/src/commands/sshkeys-lint
@@ -142,10 +142,10 @@ sub ak_comment {
 sub fprint {
     local $_ = shift;
     my ( $fh, $tempfn, $in );
-    if (/ssh-(dss|rsa) /) {
+    if (/ssh-(dss|rsa) / || /ecdsa-sha2-nistp[0-9]*/) {
         # an actual key was passed.  Since ssh-keygen requires an actual file,
         # make a temp file to take the data and pass on to ssh-keygen
-        s/^.* (ssh-dss|ssh-rsa)/$1/;
+        s/^.* (ssh-dss|ssh-rsa|ecdsa-sha2-nistp[0-9]*)/$1/;
         use File::Temp qw(tempfile);
         ( $fh, $tempfn ) = tempfile();
         $in = $tempfn;


### PR DESCRIPTION
Adding elliptic curve ssh key support in sshkey-lint
