### PR TITLE
Fix ambiguous shift usage.

### DIFF
--- a/src/triggers/post-compile/ssh-authkeys
+++ b/src/triggers/post-compile/ssh-authkeys
@@ -121,7 +121,7 @@ sub fp_file {
 
 sub fp_line {
     my ( $fh, $fn ) = tempfile();
-    print $fh shift . "\n";
+    print $fh shift() . "\n";
     close $fh;
     my $fp = fp_file($fn);
     unlink $fn;


### PR DESCRIPTION
I was getting a warning from perl during pushes of the gitolite-admin repo.  The line traced to an ambiguous usage of shift being concatenated with a newline char.
The perl version on the server is "This is perl, v5.8.8 built for x86_64-linux-thread-multi"
It is an annoying message and off-putting to other developers as I evaluate migrating to gitolite for management. 

$ git push
Counting objects: 8, done.
Delta compression using up to 8 threads.
Compressing objects: 100% (4/4), done.
Writing objects: 100% (6/6), 952 bytes, done.
Total 6 (delta 0), reused 0 (delta 0)
remote: WARNING: Warning: Use of "shift" without parentheses is ambiguous at /home/git/gitolite/src/triggers/post-compile/ssh-authkeys line 124, <DATA> line 1.
