### PR TITLE
A minor portability fix for Solaris.

### DIFF
--- a/install
+++ b/install
@@ -65,7 +65,7 @@ my $version = `git describe --tags --long --dirty=-dt`;
 
 if ($to) {
     _mkdir($to);
-    system("cp -a * $to");
+    system("cp -RpP * $to");
     _print( "$to/VERSION", $version );
 } elsif ($ln) {
     ln_sf( $ENV{GL_BINDIR}, "gitolite", $ln );


### PR DESCRIPTION
Some older systems don't have a -a flag for cp. The -a flag also has
slightly different effects on different system, but I have replaced it
with -RpP which does appear to have a consistent effect across
different systems and works the same as -a for this particular use.
