### PR TITLE
be more restrictive when feeding GITWEB_PROJECTS_LIST

### DIFF
--- a/src/triggers/post-compile/update-gitweb-access-list
+++ b/src/triggers/post-compile/update-gitweb-access-list
@@ -25,11 +25,7 @@ plf=`gitolite query-rc GITWEB_PROJECTS_LIST`
 tmpfile=`mktemp $plf.tmp_XXXXXXXX`
 rm -f $tmpfile;
 
-(
-    gitolite list-phy-repos | gitolite access % gitweb R any | grep -v DENIED
-    gitolite list-phy-repos | gitolite git-config -r % gitweb\\.
-) |
-    cut -f1 | sort -u | sed -e 's/$/.git/' > $tmpfile
+gitolite list-phy-repos | gitolite access % gitweb R any | grep -v DENIED | cut -f1 | gitolite git-config -r % gitweb\\. | cut -f1 | sort -u | sed -e 's/$/.git/' > $tmpfile
 
 [ -f $plf ] && perl -e "chmod ( ( (stat('$plf'))[2] & 07777 ), '$tmpfile')"
 mv $tmpfile $plf


### PR DESCRIPTION
repos must be readable by gitweb users
and have at least one 'gitweb.' option

so you can hide a repo even if a global gitweb. options is set
repo  @all
      config gitweb.owner = "Owner"

repo  hidden
      -  =  gitweb
