### PR TITLE
Typo in last test in 0-me-first

### DIFF
--- a/t/0-me-first.t
+++ b/t/0-me-first.t
@@ -11,7 +11,7 @@ my $rb = `gitolite query-rc -n GL_REPO_BASE`;
 # initial smoke tests
 # ----------------------------------------------------------------------
 
-try "plan 71";
+try "plan 72";
 
 # basic push admin repo
 confreset;confadd '
@@ -89,7 +89,7 @@ try "
 
     glt perms u4 -c cc/bar/baz/../frob + READERS u2
                                     !ok;    /FATAL: no relative paths allowed anywhere!/
-                                    'cc/bar/baz/\\.\\./frob' contains '\\.\\.'/
+                                           !/'cc/bar/baz/\\.\\./frob' contains '\\.\\.'/
 
 
 ";


### PR DESCRIPTION
This test isn't recognized without a leading / and should fail.
