### PR TITLE
check if command starts with shell in shell mode

### DIFF
--- a/src/gitolite-shell
+++ b/src/gitolite-shell
@@ -39,7 +39,7 @@ _die "I don't like newlines in the command: '$soc'\n" if $ENV{SSH_ORIGINAL_COMMA
 # allow gitolite-shell to be used as "$SHELL".  Experts only; no support, no docs
 if (@ARGV and $ARGV[0] eq '-c') {
     shift;
-    $ARGV[0] =~ s/^$0 //;
+    _die "Shell mode of gitolite-shell used, but command doesn't begin with it's pathname." unless $ARGV[0] =~ s/^$0 //;
 }
 
 # the INPUT trigger massages @ARGV and $ENV{SSH_ORIGINAL_COMMAND} as needed


### PR DESCRIPTION
As per discussion in:
https://groups.google.com/forum/#!msg/gitolite/eLTiK8hvijo/9dKI8YfTSecJ
added another check whether the command actually starts with the pathname to
gitolite-shell when shell mode is used.

Signed-off-by: Christoph Anton Mitterer <mail@christoph.anton.mitterer.name>