### PR TITLE
Trivial cosmetic patch:  replace perl warning with user friendly message

### DIFF
--- a/src/lib/Gitolite/Conf/Load.pm
+++ b/src/lib/Gitolite/Conf/Load.pm
@@ -236,7 +236,8 @@ sub sanity {
     my ($repo, $patt) = @_;
     $patt ||= $REPOPATT_PATT;
 
-    _die "invalid repo '$repo'" if not( $repo and $repo =~ $patt );
+    _die "no repo specified" if not( $repo );
+    _die "invalid repo '$repo'" if not( $repo =~ $patt );
     _die "'$repo' ends with a '/'"  if $repo =~ m(/$);
     _die "'$repo' contains '..'"    if $repo =~ $REPONAME_PATT and $repo =~ m(\.\.);
     _die "'$repo' contains '.git/'" if $repo =~ $REPONAME_PATT and $repo =~ m(\.git/);


### PR DESCRIPTION
Omitting a repo name in some commands produces a perl warning:

  shell:~$ ssh git@example.com perms -l
  WARNING: Use of uninitialized value $repo in concatenation (.) or
  string at /srv/git/gitolite/src/lib/Gitolite/Conf/Load.pm line 239,
  <DATA> line 1.

  FATAL: invalid repo ''

This commit makes gitolite output this instead:

  shell:~$ ssh git@example.com perms -l
  FATAL: no repo specified