### PR TITLE
Allow repos to be under symlinks.

### DIFF
--- a/src/lib/Gitolite/Common.pm
+++ b/src/lib/Gitolite/Common.pm
@@ -226,7 +226,7 @@ sub cleanup_conf_line {
         # receiving *any* arg invalidates cache)
         return \@phy_repos if ( @phy_repos and not @_ );
 
-        for my $repo (`find . -name "*.git" -prune`) {
+        for my $repo (`find . -follow -name "*.git" -prune`) {
             chomp($repo);
             $repo =~ s(\./(.*)\.git$)($1);
             push @phy_repos, $repo;


### PR DESCRIPTION
If a single disk is not enough for all the repos, one has to
use symlinks to split them between disks.