### PR TITLE
fix splitkeys on non Linux OS, e.g. OSX and Solaris

### DIFF
--- a/src/triggers/post-compile/ssh-authkeys-split
+++ b/src/triggers/post-compile/ssh-authkeys-split
@@ -46,7 +46,7 @@ find . -type f -name "*.pub" | while read k
 do
     # do we need to split?
     lines=`wc -l < $k`
-    [ "$lines" = "1" ] && continue
+    [ "$lines" -le "1" ] && continue
 
     # is it sane to split?
     base=`basename $k .pub`


### PR DESCRIPTION
On non Linux OS the 'wc' command contains leading TAB which leads to a failure in string comparison.

Solution compare as integers instead of strings. Further it also fixes 0 line counts on missing newline '\n' at the end of a public key.