### PR TITLE
Conf::Store: Fix missing hooks dir for symlink

### DIFF
--- a/src/lib/Gitolite/Conf/Store.pm
+++ b/src/lib/Gitolite/Conf/Store.pm
@@ -363,6 +363,7 @@ sub store_common {
             chmod 0755, "$rc{GL_ADMIN_BASE}/hooks/gitolite-admin/post-update";
             $hook_reset++;
         }
+	_mkdir("$repo.git/hooks");
 
         # propagate user-defined (custom) hooks to all repos
         ln_sf( "$rc{LOCAL_CODE}/hooks/common", "*", "$repo.git/hooks" ) if $rc{LOCAL_CODE};


### PR DESCRIPTION
Trivial patch to fix the fact that when doing a first-time gitolite setup -pk <user>.pub that one gets a failure due to the gitolite-admin.git/hooks dir not getting created.