### PR TITLE
configurable gitolite-admin repo

### DIFF
--- a/src/commands/sskm
+++ b/src/commands/sskm
@@ -129,7 +129,7 @@ END { `/bin/rm -rf $TEMPDIR`; }
 
 sub cd_temp_clone {
     chomp($TEMPDIR);
-    hushed_git( "clone", "$rb/gitolite-admin.git", "$TEMPDIR" );
+    hushed_git( "clone", "$rb/$rc{GL_ADMIN_REPO}.git", "$TEMPDIR" );
     chdir($TEMPDIR);
     my $hostname = `hostname`; chomp($hostname);
     hushed_git( "config", "--get", "user.email" ) and hushed_git( "config", "user.email", $ENV{USER} . "@" . $hostname );

--- a/src/commands/sudo
+++ b/src/commands/sudo
@@ -11,7 +11,7 @@ usage() { perl -lne 'print substr($_, 2) if /^# Usage/../^$/' < $0; exit 1; }
 [ "$1" = "-h" ] && usage
 [ -z "$GL_USER" ] && die GL_USER not set
 
-gitolite access -q gitolite-admin $GL_USER W any || die "You are not authorised"
+gitolite access -q $rc{GL_ADMIN_REPO} $GL_USER W any || die "You are not authorised"
 
 user="$1"; shift
 cmd="$1"; shift

--- a/src/lib/Gitolite/Conf/Store.pm
+++ b/src/lib/Gitolite/Conf/Store.pm
@@ -356,11 +356,11 @@ sub store_common {
         # them, but only once per run
         if ( not $hook_reset ) {
             _mkdir("$rc{GL_ADMIN_BASE}/hooks/common");
-            _mkdir("$rc{GL_ADMIN_BASE}/hooks/gitolite-admin");
+            _mkdir("$rc{GL_ADMIN_BASE}/hooks/$rc{GL_ADMIN_REPO}");
             _print( "$rc{GL_ADMIN_BASE}/hooks/common/update",              update_hook() );
-            _print( "$rc{GL_ADMIN_BASE}/hooks/gitolite-admin/post-update", post_update_hook() );
+            _print( "$rc{GL_ADMIN_BASE}/hooks/$rc{GL_ADMIN_REPO}/post-update", post_update_hook() );
             chmod 0755, "$rc{GL_ADMIN_BASE}/hooks/common/update";
-            chmod 0755, "$rc{GL_ADMIN_BASE}/hooks/gitolite-admin/post-update";
+            chmod 0755, "$rc{GL_ADMIN_BASE}/hooks/$rc{GL_ADMIN_REPO}/post-update";
             $hook_reset++;
         }
 
@@ -370,7 +370,7 @@ sub store_common {
         # override/propagate gitolite defined hooks for all repos
         ln_sf( "$rc{GL_ADMIN_BASE}/hooks/common", "*", "$repo.git/hooks" );
         # override/propagate gitolite defined hooks for the admin repo
-        ln_sf( "$rc{GL_ADMIN_BASE}/hooks/gitolite-admin", "*", "$repo.git/hooks" ) if $repo eq 'gitolite-admin';
+        ln_sf( "$rc{GL_ADMIN_BASE}/hooks/$rc{GL_ADMIN_REPO}", "*", "$repo.git/hooks" ) if $repo eq '$rc{GL_ADMIN_REPO}';
     }
 }
 

--- a/src/lib/Gitolite/Easy.pm
+++ b/src/lib/Gitolite/Easy.pm
@@ -78,7 +78,7 @@ my $user;
 
 sub is_admin {
     valid_user();
-    return not( access( 'gitolite-admin', $user, 'W', 'any' ) =~ /DENIED/ );
+    return not( access( '$rc{GL_ADMIN_REPO}', $user, 'W', 'any' ) =~ /DENIED/ );
 }
 
 # is_super_admin()
@@ -89,10 +89,10 @@ sub is_admin {
 # repo
 
 # shell equivalent
-#   if gitolite access -q gitolite-admin $GL_USER W VREF/NAME/; then ...
+#   if gitolite access -q $rc{GL_ADMIN_REPO} $GL_USER W VREF/NAME/; then ...
 sub is_super_admin {
     valid_user();
-    return not( access( 'gitolite-admin', $user, 'W', 'VREF/NAME/' ) =~ /DENIED/ );
+    return not( access( '$rc{GL_ADMIN_REPO}', $user, 'W', 'VREF/NAME/' ) =~ /DENIED/ );
 }
 
 # in_group()

--- a/src/lib/Gitolite/Rc.pm
+++ b/src/lib/Gitolite/Rc.pm
@@ -40,6 +40,7 @@ $rc{GL_LIBDIR} = $ENV{GL_LIBDIR};
 # these keys could be overridden by the rc file later
 $rc{GL_REPO_BASE}  = "$ENV{HOME}/repositories";
 $rc{GL_ADMIN_BASE} = "$ENV{HOME}/.gitolite";
+$rc{GL_ADMIN_REPO} = "gitolite-admin";
 $rc{LOG_TEMPLATE}  = "$ENV{HOME}/.gitolite/logs/gitolite-%y-%m.log";
 
 # variables that should probably never be changed but someone will want to, I'll bet...
@@ -564,6 +565,12 @@ __DATA__
         # called "local" in your gitolite-admin repo.  For a SECURITY WARNING
         # on this, see http://gitolite.com/gitolite/non-core.html#pushcode
         # LOCAL_CODE                =>  "$rc{GL_ADMIN_BASE}/local",
+
+    # ------------------------------------------------------------------
+
+    # suggested name for gitolite-admin repo
+
+    # GL_ADMIN_REPO                   =>  "gitolite-admin",
 
     # ------------------------------------------------------------------
 

--- a/src/lib/Gitolite/Setup.pm
+++ b/src/lib/Gitolite/Setup.pm
@@ -115,9 +115,6 @@ sub setup_gladmin {
     _die "'-pk' or '-a' required; see 'gitolite setup -h' for more"
       if not $admin and not -f "$rc{GL_ADMIN_BASE}/conf/gitolite.conf";
 
-    # reminder: 'admin files' are in ~/.gitolite, 'admin repo' is
-    # $rc{GL_REPO_BASE}/gitolite-admin.git
-
     # grab the pubkey content before we chdir() away
     my $pubkey_content = '';
     $pubkey_content = slurp($pubkey) if $pubkey;
@@ -135,6 +132,7 @@ sub setup_gladmin {
         $conf = <DATA>;
     }
     $conf =~ s/%ADMIN/$admin/g;
+    $conf =~ s/%REPO_DE_ADMIN/$rc{GL_ADMIN_REPO}/g;
 
     _print( "conf/gitolite.conf", $conf ) if not -f "conf/gitolite.conf";
 
@@ -146,15 +144,14 @@ sub setup_gladmin {
     # set up the admin repo in repo-base
 
     _chdir();
-    _mkdir( $rc{GL_REPO_BASE} );
-    _chdir( $rc{GL_REPO_BASE} );
-
-    new_repo("gitolite-admin") if not -d "gitolite-admin.git";
+    _mkdir( "$rc{GL_REPO_BASE}" );
+    _chdir( "$rc{GL_REPO_BASE}" );
+    new_repo("$rc{GL_ADMIN_REPO}") if not -d "$rc{GL_ADMIN_REPO}.git";
 
     # commit the admin files to the admin repo
 
     $ENV{GIT_WORK_TREE} = $rc{GL_ADMIN_BASE};
-    _chdir("$rc{GL_REPO_BASE}/gitolite-admin.git");
+    _chdir("$rc{GL_REPO_BASE}/$rc{GL_ADMIN_REPO}.git");
     _system("git add conf/gitolite.conf");
     _system("git add keydir") if $pubkey;
     tsh_try("git config --get user.email") or tsh_run( "git config user.email $ENV{USER}\@" . `hostname` );
@@ -168,7 +165,7 @@ sub setup_gladmin {
 1;
 
 __DATA__
-repo gitolite-admin
+repo %REPO_DE_ADMIN
     RW+     =   %ADMIN
 
 repo testing

--- a/src/lib/Gitolite/Test.pm
+++ b/src/lib/Gitolite/Test.pm
@@ -21,6 +21,7 @@ use File::Path qw(mkpath);
 use Carp qw(carp cluck croak confess);
 use Digest::MD5 qw(md5_hex);
 
+use Gitolite::Rc;
 use Gitolite::Common;
 
 BEGIN {
@@ -48,11 +49,11 @@ try "
     DEF gsh = /TRACE: gsh.SOC=/
     DEF reject = /hook declined to update/; /remote rejected.*hook declined/; /error: failed to push some refs to/
 
-    DEF AP_1 = cd ../gitolite-admin; ok or die cant find admin repo clone;
+    DEF AP_1 = cd ../$rc{GL_ADMIN_REPO}; ok or die cant find admin repo clone;
     DEF AP_2 = AP_1; git add conf ; ok; git commit -m %1; ok; /master.* %1/
     DEF ADMIN_PUSH = AP_2 %1; glt push admin origin; ok; gsh; /master -> master/
 
-    DEF CS_1 = pwd; //tmp/tsh_tempdir.*gitolite-admin/; git remote -v; ok; /file:///gitolite-admin/
+    DEF CS_1 = pwd; //tmp/tsh_tempdir.*$rc{GL_ADMIN_REPO}/; git remote -v; ok; /file:///$rc{GL_ADMIN_REPO}/
     DEF CHECK_SETUP = CS_1; git log; ok; /fa7564c1b903ea3dce49314753f25b34b9e0cea0/
 
     DEF CLONE = glt clone %1 file:///%2
@@ -72,8 +73,8 @@ try "
 
     # clone admin repo
     cd tsh_tempdir
-    glt clone admin --progress file:///gitolite-admin
-    cd gitolite-admin
+    glt clone admin --progress file:///$rc{GL_ADMIN_REPO}
+    cd $rc{GL_ADMIN_REPO}
 " or die "could not setup the test environment; errors:\n\n" . text() . "\n\n";
 
 sub dump {
@@ -89,16 +90,16 @@ sub _confargs {
 }
 
 sub confreset {
-    chdir("../gitolite-admin") or die "in `pwd`, could not cd ../g-a";
+    chdir("../$rc{GL_ADMIN_REPO}") or die "in `pwd`, could not cd ../g-a";
     system( "rm", "-rf", "conf" );
     mkdir("conf");
-    system("mv ~/repositories/gitolite-admin.git ~/repositories/.ga");
+    system("mv ~/repositories/$rc{GL_ADMIN_REPO}.git ~/repositories/.ga");
     system("mv ~/repositories/testing.git        ~/repositories/.te");
     system("find ~/repositories -name '*.git' |xargs rm -rf");
-    system("mv ~/repositories/.ga ~/repositories/gitolite-admin.git");
+    system("mv ~/repositories/.ga ~/repositories/$rc{GL_ADMIN_REPO}.git");
     system("mv ~/repositories/.te ~/repositories/testing.git       ");
     put "|cut -c9- > conf/gitolite.conf", '
-        repo    gitolite-admin
+        repo    $rc{GL_ADMIN_REPO}
             RW+     =   admin
         repo    testing
             RW+     =   @all
@@ -106,7 +107,7 @@ sub confreset {
 }
 
 sub confadd {
-    chdir("../gitolite-admin") or die "in `pwd`, could not cd ../g-a";
+    chdir("../$rc{GL_ADMIN_REPO}") or die "in `pwd`, could not cd ../g-a";
     my ( $file, $string ) = _confargs(@_);
     put "|cat >> conf/$file", $string;
 }

--- a/src/triggers/post-compile/update-git-daemon-access-list
+++ b/src/triggers/post-compile/update-git-daemon-access-list
@@ -35,7 +35,7 @@ for my $d (`gitolite list-phy-repos | gitolite access % daemon R any`) {
 #   bar^Idaemon^IR any bar daemon DENIED by fallthru$
 #   foo^Idaemon^Irefs/.*$
 #   fubar^Idaemon^Irefs/.*$
-#   gitolite-admin^Idaemon^IR any gitolite-admin daemon DENIED by fallthru$
+#   $rc{GL_ADMIN_REPO}^Idaemon^IR any $rc{GL_ADMIN_REPO} daemon DENIED by fallthru$
 #   testing^Idaemon^Irefs/.*$
 
 # where I've typed "^I" to denote a tab.

--- a/src/triggers/repo-specific-hooks
+++ b/src/triggers/repo-specific-hooks
@@ -38,7 +38,7 @@ while (<>) {
     next unless @codes;
 
     # this is a special case
-    if ( $repo eq 'gitolite-admin' and $hook eq 'post-update' ) {
+    if ( $repo eq '$rc{GL_ADMIN_REPO}' and $hook eq 'post-update' ) {
         _warn "repo-specific-hooks: ignoring attempts to set post-update hook for the admin repo";
         next;
     }


### PR DESCRIPTION
I read the message below, but this seems like a pretty trivial change. I introduced a variable name for the gitolite-admin repo. Will run git-format-patch and send via email, as well.

----------------------------------------------------------------------------------------
Go to http://gitolite.com/gitolite/index.html#contact for information on
contacting me, the mailing list, and IRC channel.  *Unless you are reporting
what you think is a security issue, I prefer you send to the mailing list,
not to me directly.*

Please DO NOT send messages via github's "issues" system, linkedin
comments/discussion, stackoverflow questions, google+, and any other Web 3.0
"coolness". (The issues system does have an email interface, but it is not a
substitute for email. I can't cc anyone else when I want to, for instance.
Well I can, but any response the original requester then makes using the
website will not get cc-d to the person I cc-d).

Please send patches *via email*, not as github pull requests. Again, if you
think it's a security issue, send it directly to my gmail address, but
otherwise please send it to the mailing list, so others can see it and comment
on it.

The preferred format is the files created by git-format-patch, as attachments.
However, if your repo has a public clone URL, you can make a new branch just
for this fix, and send the repo URL and branch name to the mailing list.

(If you do send me a github pull request, I may take it if it's a trivial
patch, but otherwise I'll ask you to close the pull request, then read
this URL for how to send me the patch.)
