### PR TITLE
Update ukm for modern perl

### DIFF
--- a/contrib/commands/ukm
+++ b/contrib/commands/ukm
@@ -293,7 +293,7 @@ sub sanitize_pubkeypath {
 # This function is only relavant for guest key managers.
 # It returns true if the pattern is OK and false otherwise.
 sub required_guest_keyid {
-    my ($_) = @_;
+    local ($_) = @_;
     /$required_guest_pattern/ and ! /$forbidden_guest_pattern/;
 }
 


### PR DESCRIPTION
with perl 5.32.0 trying to use ukm gives:

```
$ ssh gitolite@localhost ukm
Enter passphrase for key '/home/kousu/.ssh/id_rsa': 
FATAL: Can't use global $_ in "my" at /usr/lib/gitolite/commands/ukm line 296, near "($_"
Execution of /usr/lib/gitolite/commands/ukm aborted due to compilation errors.
```

This fixes it

```
$ ssh gitolite@localhost ukm list
Enter passphrase for key '/home/kousu/.ssh/id_rsa': 
Hello alice, you manage the following keys:
fingerprint                                     userid keyid
SHA256:VxHhqhOq5GxpPPUrYMeFMly4Mdc3YlP40qkLX4gr5fI alice  alice
```